### PR TITLE
Add missing pytests for events

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,7 @@ exclude =
     gen_resources,
     build,
 extend-ignore=F401,E704,E226
+
+# Allow assigning lambdas in tests
+per-file-ignores =
+    tests/*:E731

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+from unittest.mock import Mock
+
+
+class Observer(Mock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+class NoParametersObserver(Observer):
+    def __call__(self):
+        super().__call__()
+
+
+class OneParameterObserver(Observer):
+    def __call__(self, param0):
+        super().__call__(param0)
+
+
+class OneDefaultParameterObserver(Observer):
+    def __call__(self, param0="default"):
+        super().__call__(param0)
+
+
+class TwoParametersObserver(Observer):
+    def __call__(self, param0, param1):
+        super().__call__(param0, param1)
+
+
+class OneRequiredOneDefaultParameterObserver(Observer):
+    def __call__(self, param0, param1="default"):
+        super().__call__(param0, param1)
+
+
+class TwoDefaultParametersObserver(Observer):
+    def __call__(self, param0="default0", param1="default1"):
+        super().__call__(param0, param1)
+
+
+class ThreeParametersObserver(Observer):
+    def __call__(self, param0, param1, param2):
+        super().__call__(param0, param1, param2)
+
+
+class ThreeDefaultParametersObserver(Observer):
+    def __call__(self, param0="default0", param1="default1", param2="default2"):
+        super().__call__(param0=param0, param1=param1, param2=param2)
+
+
+class TwoRequiredOneDefaultParameterObserver(Observer):
+    def __call__(self, param0, param1, param2="default2"):
+        super().__call__(param0, param1, param2)

--- a/tests/test_bi_events.py
+++ b/tests/test_bi_events.py
@@ -1,0 +1,213 @@
+import pytest
+from pybind.event import BiEvent
+from conftest import NoParametersObserver, OneParameterObserver, OneDefaultParameterObserver, \
+    OneRequiredOneDefaultParameterObserver, TwoParametersObserver, TwoDefaultParametersObserver
+
+
+def test_bi_event_observe_and_call_no_parameters_mock_observer():
+    event = BiEvent[str, int]()
+    observer = NoParametersObserver()
+
+    event.observe(observer)
+    event("test_value", 42)
+
+    observer.assert_called_once_with()
+
+
+def test_bi_event_observe_and_call_one_parameter_mock_observer():
+    event = BiEvent[str, int]()
+    observer = OneParameterObserver()
+
+    event.observe(observer)
+    event("test_value", 42)
+
+    observer.assert_called_once_with("test_value")
+
+
+def test_bi_event_observe_and_call_one_default_parameter_mock_observer():
+    event = BiEvent[str, int]()
+    observer = OneDefaultParameterObserver()
+
+    event.observe(observer)
+    event("test_value", 42)
+
+    observer.assert_called_once_with("test_value")
+
+
+def test_bi_event_observe_and_call_one_required_one_default_parameter_mock_observer():
+    event = BiEvent[str, int]()
+    observer = OneRequiredOneDefaultParameterObserver()
+
+    event.observe(observer)
+    event("test_value", 42)
+
+    observer.assert_called_once_with("test_value", 42)
+
+
+def test_bi_event_observe_and_call_two_parameters_mock_observer():
+    event = BiEvent[str, int]()
+    observer = TwoParametersObserver()
+
+    event.observe(observer)
+    event("test_value", 42)
+
+    observer.assert_called_once_with("test_value", 42)
+
+
+def test_bi_event_observe_and_call_two_default_parameters_mock_observer():
+    event = BiEvent[str, int]()
+    observer = TwoDefaultParametersObserver()
+
+    event.observe(observer)
+    event("test_value", 42)
+
+    observer.assert_called_once_with("test_value", 42)
+
+
+def test_bi_event_unobserve_mock_observer():
+    event = BiEvent[str, int]()
+    observer = TwoParametersObserver()
+
+    event.observe(observer)
+    event.unobserve(observer)
+    event("test", 42)
+
+    observer.assert_not_called()
+
+
+def test_bi_event_multiple_mock_observers():
+    event = BiEvent[str, int]()
+    observer0 = NoParametersObserver()
+    observer1 = OneParameterObserver()
+    observer2 = TwoParametersObserver()
+
+    event.observe(observer0)
+    event.observe(observer1)
+    event.observe(observer2)
+    event("hello", 123)
+
+    observer0.assert_called_once_with()
+    observer1.assert_called_once_with("hello")
+    observer2.assert_called_once_with("hello", 123)
+
+
+def test_bi_event_function_observer_with_too_many_parameters():
+    event = BiEvent[str, int]()
+
+    def bad_observer(param0, param1, param2):
+        pass
+
+    with pytest.raises(ValueError):
+        event.observe(bad_observer)
+
+
+def test_bi_event_observe_and_call_lambda_no_parameters():
+    event = BiEvent[str, int]()
+    called = []
+
+    event.observe(lambda: called.append(True))
+    event("test_value", 42)
+
+    assert called == [True]
+
+
+def test_bi_event_observe_and_call_lambda_one_parameter():
+    event = BiEvent[str, int]()
+    calls = []
+
+    event.observe(lambda value0: calls.append(value0))
+    event("test_value", 42)
+
+    assert calls == ["test_value"]
+
+
+def test_bi_event_observe_and_call_lambda_two_parameters():
+    event = BiEvent[str, int]()
+    calls = []
+
+    event.observe(lambda value0, value1: calls.append((value0, value1)))
+    event("test_value", 42)
+
+    assert calls == [("test_value", 42)]
+
+
+def test_bi_event_unobserve_lambda():
+    event = BiEvent[str, int]()
+    calls = []
+    observer = lambda value0, value1: calls.append((value0, value1))
+
+    event.observe(observer)
+    event("test0", 0)
+    event.unobserve(observer)
+    event("test1", 1)
+
+    assert calls == [("test0", 0)]
+
+
+def test_bi_event_lambda_with_too_many_parameters():
+    event = BiEvent[str, int]()
+
+    with pytest.raises(ValueError):
+        event.observe(lambda param0, param1, param2: None)
+
+
+def test_bi_event_call_with_one_parameter():
+    event = BiEvent[str, int]()
+
+    with pytest.raises(TypeError):
+        event("param0")
+
+
+def test_bi_event_call_with_three_parameters():
+    event = BiEvent[str, int]()
+
+    with pytest.raises(TypeError):
+        event("param0", 42, "param2")
+
+
+def test_bi_event_unobserve_non_existent_observer():
+    event = BiEvent[str, int]()
+    observer = TwoParametersObserver()
+
+    with pytest.raises(ValueError):
+        event.unobserve(observer)
+
+
+def test_bi_event_observe_same_observer_multiple_times():
+    event = BiEvent[str, int]()
+    observer = TwoParametersObserver()
+
+    event.observe(observer)
+    event.observe(observer)
+    event("test", 42)
+
+    assert observer.call_count == 2
+    observer.assert_called_with("test", 42)
+
+
+def test_bi_event_call_with_no_observers():
+    event = BiEvent[str, int]()
+    event("test_value", 42)  # Should not raise
+
+
+def test_bi_event_observers_called_in_order():
+    event = BiEvent[str, int]()
+    call_order = []
+
+    event.observe(lambda value0, value1: call_order.append("first"))
+    event.observe(lambda value0, value1: call_order.append("second"))
+    event.observe(lambda value0, value1: call_order.append("third"))
+
+    event("test", 42)
+
+    assert call_order == ["first", "second", "third"]
+
+
+def test_bi_event_call_with_none_values():
+    event = BiEvent[str | None, int | None]()
+    observer = TwoParametersObserver()
+
+    event.observe(observer)
+    event(None, None)
+
+    observer.assert_called_once_with(None, None)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,27 +1,7 @@
 import pytest
-from unittest.mock import Mock
 
+from conftest import NoParametersObserver, OneParameterObserver, OneDefaultParameterObserver
 from pybind.event import Event
-
-
-class Observer(Mock):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-
-class NoParametersObserver(Observer):
-    def __call__(self):
-        super().__call__()
-
-
-class OneParameterObserver(Observer):
-    def __call__(self, param0):
-        super().__call__(param0)
-
-
-class OneDefaultParameterObserver(Observer):
-    def __call__(self, param0="default"):
-        super().__call__(param0=param0)
 
 
 def test_event_initialization():
@@ -94,7 +74,7 @@ def test_mock_observer_with_default_parameter():
     event.observe(observer)
     event()
 
-    observer.assert_called_once_with(param0="default")
+    observer.assert_called_once_with("default")
 
 
 def test_call_with_no_observers():

--- a/tests/test_tri_events.py
+++ b/tests/test_tri_events.py
@@ -1,0 +1,245 @@
+import pytest
+from pybind.event import TriEvent
+from conftest import NoParametersObserver, OneParameterObserver, OneDefaultParameterObserver, \
+    OneRequiredOneDefaultParameterObserver, TwoParametersObserver, TwoDefaultParametersObserver, \
+    ThreeParametersObserver, ThreeDefaultParametersObserver, TwoRequiredOneDefaultParameterObserver
+
+
+def test_tri_event_observe_and_call_no_parameters_mock_observer():
+    event = TriEvent[str, int, bool]()
+    observer = NoParametersObserver()
+
+    event.observe(observer)
+    event("test_value", 42, True)
+
+    observer.assert_called_once_with()
+
+
+def test_tri_event_observe_and_call_one_parameter_mock_observer():
+    event = TriEvent[str, int, bool]()
+    observer = OneParameterObserver()
+
+    event.observe(observer)
+    event("test_value", 42, True)
+
+    observer.assert_called_once_with("test_value")
+
+
+def test_tri_event_observe_and_call_one_default_parameter_mock_observer():
+    event = TriEvent[str, int, bool]()
+    observer = OneDefaultParameterObserver()
+
+    event.observe(observer)
+    event("test_value", 42, True)
+
+    observer.assert_called_once_with("test_value")
+
+
+def test_tri_event_observe_and_call_one_required_one_default_parameter_mock_observer():
+    event = TriEvent[str, int, bool]()
+    observer = OneRequiredOneDefaultParameterObserver()
+
+    event.observe(observer)
+    event("test_value", 42, True)
+
+    observer.assert_called_once_with("test_value", 42)
+
+
+def test_tri_event_observe_and_call_two_parameters_mock_observer():
+    event = TriEvent[str, int, bool]()
+    observer = TwoParametersObserver()
+
+    event.observe(observer)
+    event("test_value", 42, True)
+
+    observer.assert_called_once_with("test_value", 42)
+
+
+def test_tri_event_observe_and_call_two_required_one_default_parameter_mock_observer():
+    event = TriEvent[str, int, bool]()
+    observer = TwoRequiredOneDefaultParameterObserver()
+
+    event.observe(observer)
+    event("test_value", 42, True)
+
+    observer.assert_called_once_with("test_value", 42, True)
+
+
+def test_tri_event_observe_and_call_three_parameters_mock_observer():
+    event = TriEvent[str, int, bool]()
+    observer = ThreeParametersObserver()
+
+    event.observe(observer)
+    event("test_value", 42, True)
+
+    observer.assert_called_once_with("test_value", 42, True)
+
+
+def test_tri_event_unobserve_mock_observer():
+    event = TriEvent[str, int, bool]()
+    observer = ThreeParametersObserver()
+
+    event.observe(observer)
+    event("test0", 0, False)
+    event.unobserve(observer)
+    event("test1", 1, True)
+
+    observer.assert_called_once_with("test0", 0, False)
+
+
+def test_tri_event_multiple_mock_observers():
+    event = TriEvent[str, int, bool]()
+    observer0 = NoParametersObserver()
+    observer1 = OneParameterObserver()
+    observer2 = TwoParametersObserver()
+    observer3 = ThreeParametersObserver()
+
+    event.observe(observer0)
+    event.observe(observer1)
+    event.observe(observer2)
+    event.observe(observer3)
+    event("hello", 123, False)
+
+    observer0.assert_called_once_with()
+    observer1.assert_called_once_with("hello")
+    observer2.assert_called_once_with("hello", 123)
+    observer3.assert_called_once_with("hello", 123, False)
+
+
+def test_tri_event_function_observer_with_too_many_parameters():
+    event = TriEvent[str, int, bool]()
+
+    def bad_observer(param0, param1, param2, param3):
+        pass
+
+    with pytest.raises(ValueError):
+        event.observe(bad_observer)
+
+
+def test_tri_event_observe_and_call_lambda_no_parameters():
+    event = TriEvent[str, int, bool]()
+    calls = []
+
+    event.observe(lambda: calls.append(True))
+    event("test_value", 42, False)
+
+    assert calls == [True]
+
+
+def test_tri_event_observe_and_call_lambda_one_parameter():
+    event = TriEvent[str, int, bool]()
+    calls = []
+
+    event.observe(lambda value0: calls.append(value0))
+    event("test_value", 42, False)
+
+    assert calls == ["test_value"]
+
+
+def test_tri_event_observe_and_call_lambda_two_parameters():
+    event = TriEvent[str, int, bool]()
+    calls = []
+
+    event.observe(lambda value0, value1: calls.append((value0, value1)))
+    event("test_value", 42, False)
+
+    assert calls == [("test_value", 42)]
+
+
+def test_tri_event_observe_and_call_lambda_three_parameters():
+    event = TriEvent[str, int, bool]()
+    calls = []
+
+    event.observe(lambda value0, value1, value2: calls.append((value0, value1, value2)))
+    event("test_value", 42, False)
+
+    assert calls == [("test_value", 42, False)]
+
+
+def test_tri_event_unobserve_lambda():
+    event = TriEvent[str, int, bool]()
+    calls = []
+    observer = lambda value0, value1, value2: calls.append((value0, value1, value2))
+
+    event.observe(observer)
+    event("test0", 0, False)
+    event.unobserve(observer)
+    event("test1", 1, True)
+
+    assert calls == [("test0", 0, False)]
+
+
+def test_tri_event_lambda_with_too_many_parameters():
+    event = TriEvent[str, int, bool]()
+
+    with pytest.raises(ValueError):
+        event.observe(lambda param0, param1, param2, param3: None)
+
+
+def test_tri_event_call_with_one_parameter():
+    event = TriEvent[str, int, bool]()
+
+    with pytest.raises(TypeError):
+        event("param0")
+
+
+def test_tri_event_call_with_two_parameters():
+    event = TriEvent[str, int, bool]()
+
+    with pytest.raises(TypeError):
+        event("param0", 42)
+
+
+def test_tri_event_call_with_four_parameters():
+    event = TriEvent[str, int, bool]()
+
+    with pytest.raises(TypeError):
+        event("param0", 42, True, "param3")
+
+
+def test_tri_event_unobserve_non_existent_observer():
+    event = TriEvent[str, int, bool]()
+    observer = ThreeParametersObserver()
+
+    with pytest.raises(ValueError):
+        event.unobserve(observer)
+
+
+def test_tri_event_observe_same_observer_multiple_times():
+    event = TriEvent[str, int, bool]()
+    observer = ThreeParametersObserver()
+
+    event.observe(observer)
+    event.observe(observer)
+    event("test", 42, True)
+
+    assert observer.call_count == 2
+    observer.assert_called_with("test", 42, True)
+
+
+def test_tri_event_call_with_no_observers():
+    event = TriEvent[str, int, bool]()
+    event("test_value", 42, False)  # Should not raise
+
+
+def test_tri_event_observers_called_in_order():
+    event = TriEvent[str, int, bool]()
+    call_order = []
+
+    event.observe(lambda value0, value1, value2: call_order.append("first"))
+    event.observe(lambda value0, value1, value2: call_order.append("second"))
+    event.observe(lambda value0, value1, value2: call_order.append("third"))
+
+    event("test", 42, False)
+
+    assert call_order == ["first", "second", "third"]
+
+
+def test_tri_event_call_with_none_values():
+    event = TriEvent[str | None, int | None, bool | None]()
+    observer = ThreeParametersObserver()
+
+    event.observe(observer)
+    event(None, None, None)
+
+    observer.assert_called_once_with(None, None, None)

--- a/tests/test_value_events.py
+++ b/tests/test_value_events.py
@@ -1,0 +1,181 @@
+import pytest
+from pybind.event import ValueEvent
+from conftest import NoParametersObserver, OneParameterObserver, OneDefaultParameterObserver, \
+    OneRequiredOneDefaultParameterObserver
+
+
+def test_value_event_unobserve_non_existent_observer():
+    event = ValueEvent[str]()
+    observer = OneParameterObserver()
+
+    with pytest.raises(ValueError):
+        event.unobserve(observer)
+
+
+def test_value_event_observe_same_observer_multiple_times():
+    event = ValueEvent[str]()
+    observer = OneParameterObserver()
+
+    event.observe(observer)
+    event.observe(observer)
+    event("test")
+
+    assert observer.call_count == 2
+
+
+def test_value_event_call_with_no_observers():
+    event = ValueEvent[str]()
+    event("test_value")  # Should not raise
+
+
+def test_value_event_observers_called_in_order():
+    event = ValueEvent[str]()
+    call_order = []
+
+    event.observe(lambda value: call_order.append("first"))
+    event.observe(lambda value: call_order.append("second"))
+    event.observe(lambda value: call_order.append("third"))
+
+    event("test")
+
+    assert call_order == ["first", "second", "third"]
+
+
+def test_value_event_call_with_none_value():
+    event = ValueEvent[str | None]()
+    observer = OneParameterObserver()
+
+    event.observe(observer)
+    event(None)
+
+    observer.assert_called_once_with(None)
+
+
+def test_value_event_observe_and_call_no_parameters_mock_observer():
+    event = ValueEvent[str]()
+    observer = NoParametersObserver()
+
+    event.observe(observer)
+    event("test_value")
+
+    observer.assert_called_once_with()
+
+
+def test_value_event_observe_and_call_one_parameter_mock_observer():
+    event = ValueEvent[str]()
+    observer = OneParameterObserver()
+
+    event.observe(observer)
+    event("test_value")
+
+    observer.assert_called_once_with("test_value")
+
+
+def test_value_event_observe_and_call_one_default_parameter_mock_observer():
+    event = ValueEvent[str]()
+    observer = OneDefaultParameterObserver()
+
+    event.observe(observer)
+    event("test_value")
+
+    observer.assert_called_once_with("test_value")
+
+
+def test_value_event_observe_and_call_one_required_one_default_parameter_mock_observer():
+    event = ValueEvent[str]()
+    observer = OneRequiredOneDefaultParameterObserver()
+
+    event.observe(observer)
+    event("test_value")
+
+    observer.assert_called_once_with("test_value", "default")
+
+
+def test_value_event_unobserve_mock_observer():
+    event = ValueEvent[int]()
+    observer = OneParameterObserver()
+
+    event.observe(observer)
+    event.unobserve(observer)
+    event(42)
+
+    observer.assert_not_called()
+
+
+def test_value_event_multiple_mock_observers():
+    event = ValueEvent[str]()
+    observer0 = NoParametersObserver()
+    observer1 = OneParameterObserver()
+
+    event.observe(observer0)
+    event.observe(observer1)
+    event("hello")
+
+    observer0.assert_called_once_with()
+    observer1.assert_called_once_with("hello")
+
+
+def test_value_event_observer_with_too_many_parameters():
+    event = ValueEvent[str]()
+
+    def bad_observer(param0, param1):
+        pass
+
+    with pytest.raises(ValueError):
+        event.observe(bad_observer)
+
+
+def test_value_event_observe_and_call_lambda_no_parameters():
+    event = ValueEvent[str]()
+    called = []
+
+    event.observe(lambda: called.append(True))
+    event("test_value")
+
+    assert called == [True]
+
+
+def test_value_event_observe_and_call_lambda_one_parameter():
+    event = ValueEvent[str]()
+    received_values = []
+
+    event.observe(lambda value0: received_values.append(value0))
+    event("test_value")
+
+    assert received_values == ["test_value"]
+
+
+def test_value_event_observe_and_call_lambda_one_default_parameter():
+    event = ValueEvent[str]()
+    received_values = []
+
+    event.observe(lambda value0="default": received_values.append(value0))
+    event("test_value")
+
+    assert received_values == ["test_value"]
+
+
+def test_value_event_unobserve_lambda():
+    event = ValueEvent[int]()
+    called = []
+    observer = lambda value0: called.append(value0)
+
+    event.observe(observer)
+    event.unobserve(observer)
+    event(42)
+
+    assert called == []
+
+
+def test_value_event_lambda_with_too_many_parameters():
+    event = ValueEvent[str]()
+
+    with pytest.raises(ValueError, match="has too many non-default parameters: 2 > 1"):
+        event.observe(lambda param0, param1: None)
+
+
+def test_value_event_call_with_two_parameters():
+    event = ValueEvent[str]()
+
+    with pytest.raises(TypeError):
+        event("param0", "param1")


### PR DESCRIPTION
Fix bug which was caused by a parameter not propagated if observer has default paramer at that place Move mock observers to conftest.py