### PR TITLE
Make Value inherit from Observable again

### DIFF
--- a/src/spellbind/observables.py
+++ b/src/spellbind/observables.py
@@ -195,7 +195,7 @@ class Observable(ABC):
     @abstractmethod
     def is_observed(self, by: _O | None = None) -> bool: ...
 
-    def __or__(self, other: Observable) -> Observable:
+    def or_observable(self, other: Observable) -> Observable:
         return CombinedObservable((self, other), weakly=True)
 
 
@@ -212,23 +212,23 @@ class ValueObservable(Observable, Generic[_S_co], ABC):
     @override
     def unobserve(self, observer: Observer | ValueObserver[_S_co]) -> None: ...
 
-    def map(self, transformer: Callable[[_S_co], _T], weakly: bool = False,
-            predicate: Callable[[_S_co], bool] | None = None) -> ValueObservable[_T]:
+    def map_to_value_observable(self, transformer: Callable[[_S_co], _T], weakly: bool = False,
+                                predicate: Callable[[_S_co], bool] | None = None) -> ValueObservable[_T]:
         return MappedValueObservable(self, transformer, weakly=weakly, predicate=predicate)
 
-    def map_to_two(self, transformer: Callable[[_S_co], tuple[_T, _U]], weakly: bool = False,
-                   predicate: Callable[[_S_co], bool] | None = None) -> BiObservable[_T, _U]:
+    def map_to_bi_observable(self, transformer: Callable[[_S_co], tuple[_T, _U]], weakly: bool = False,
+                             predicate: Callable[[_S_co], bool] | None = None) -> BiObservable[_T, _U]:
         return SplitOneInTwoObservable(self, transformer, weakly=weakly, predicate=predicate)
 
-    def map_to_three(self, transformer: Callable[[_S_co], tuple[_T, _U, _V]], weakly: bool = False,
-                     predicate: Callable[[_S_co], bool] | None = None) -> TriObservable[_T, _U, _V]:
+    def map_to_tri_observable(self, transformer: Callable[[_S_co], tuple[_T, _U, _V]], weakly: bool = False,
+                              predicate: Callable[[_S_co], bool] | None = None) -> TriObservable[_T, _U, _V]:
         return SplitOneInThreeObservable(self, transformer, weakly=weakly, predicate=predicate)
 
-    def map_to_many(self, transformer: Callable[[_S_co], tuple[_T, ...]], weakly: bool = False,
-                    predicate: Callable[[_S_co], bool] | None = None) -> ValuesObservable[_T]:
+    def map_to_values_observable(self, transformer: Callable[[_S_co], tuple[_T, ...]], weakly: bool = False,
+                                 predicate: Callable[[_S_co], bool] | None = None) -> ValuesObservable[_T]:
         return SplitOneInManyObservable(self, transformer, weakly=weakly, predicate=predicate)
 
-    def or_value(self, other: ValueObservable[_T]) -> ValueObservable[_S_co | _T]:
+    def or_value_observable(self, other: ValueObservable[_T]) -> ValueObservable[_S_co | _T]:
         return CombinedValueObservable((self, other), weakly=True)
 
 
@@ -247,20 +247,17 @@ class BiObservable(Observable, Generic[_S_co, _T_co], ABC):
     @override
     def unobserve(self, observer: Observer | ValueObserver[_S_co] | BiObserver[_S_co, _T_co]) -> None: ...
 
-    def map_to_one(self, transformer: Callable[[_S_co, _T_co], _U], weakly: bool = False,
-                   predicate: Callable[[_S_co, _T_co], bool] | None = None) -> ValueObservable[_U]:
+    def map_to_value_observable(self, transformer: Callable[[_S_co, _T_co], _U], weakly: bool = False,
+                                predicate: Callable[[_S_co, _T_co], bool] | None = None) -> ValueObservable[_U]:
         return MergeTwoToOneObservable(self, transformer, weakly=weakly, predicate=predicate)
 
-    def map(self, transformer: Callable[[_S_co, _T_co], tuple[_U, _V]], weakly: bool = False,
-            predicate: Callable[[_S_co, _T_co], bool] | None = None) -> BiObservable[_U, _V]:
+    def map_to_bi_observable(self, transformer: Callable[[_S_co, _T_co], tuple[_U, _V]], weakly: bool = False,
+                             predicate: Callable[[_S_co, _T_co], bool] | None = None) -> BiObservable[_U, _V]:
         return MappedBiObservable(self, transformer, weakly=weakly, predicate=predicate)
 
-    def map_to_three(self, transformer: Callable[[_S_co, _T_co], tuple[_U, _V, _W]], weakly: bool = False,
-                     predicate: Callable[[_S_co, _T_co], bool] | None = None) -> TriObservable[_U, _V, _W]:
+    def map_to_tri_observable(self, transformer: Callable[[_S_co, _T_co], tuple[_U, _V, _W]], weakly: bool = False,
+                              predicate: Callable[[_S_co, _T_co], bool] | None = None) -> TriObservable[_U, _V, _W]:
         return SplitTwoToThreeObservable(self, transformer, weakly=weakly, predicate=predicate)
-
-    def or_bi(self, other: BiObservable[_S_co, _T_co]) -> BiObservable[_S_co, _T_co]:
-        return CombinedBiObservable((self, other), weakly=True)
 
 
 class TriObservable(BiObservable[_S_co, _T_co], Generic[_S_co, _T_co, _U_co], ABC):
@@ -277,9 +274,6 @@ class TriObservable(BiObservable[_S_co, _T_co], Generic[_S_co, _T_co, _U_co], AB
     @abstractmethod
     @override
     def unobserve(self, observer: Observer | ValueObserver[_S_co] | BiObserver[_S_co, _T_co] | TriObserver[_S_co, _T_co, _U_co]) -> None: ...
-
-    def or_tri(self, other: TriObservable[_S_co, _T_co, _U_co]) -> TriObservable[_S_co, _T_co, _U_co]:
-        return CombinedTriObservable((self, other), weakly=True)
 
 
 class ValuesObservable(Observable, Generic[_S_co], ABC):
@@ -317,8 +311,25 @@ class ValuesObservable(Observable, Generic[_S_co], ABC):
             predicate: Callable[[_S_co], bool] | None = None) -> ValuesObservable[_T_co]:
         return MappedValuesObservable(self, transformer, weakly=weakly, predicate=predicate)
 
-    def or_values(self, other: ValuesObservable[_T]) -> ValuesObservable[_S_co | _T]:
-        return CombinedValuesObservable((self, other), weakly=True)
+
+def combine_observables(*observables: Observable, observe_weakly: bool = False) -> Observable:
+    return CombinedObservable(observables, weakly=observe_weakly)
+
+
+def combine_value_observables(*observables: ValueObservable[_S], observe_weakly: bool = False) -> ValueObservable[_S]:
+    return CombinedValueObservable(observables, weakly=observe_weakly)
+
+
+def combine_bi_observables(*observables: BiObservable[_S, _T], observe_weakly: bool = False) -> BiObservable[_S, _T]:
+    return CombinedBiObservable(observables, weakly=observe_weakly)
+
+
+def combine_tri_observables(*observables: TriObservable[_S, _T, _U], observe_weakly: bool = False) -> TriObservable[_S, _T, _U]:
+    return CombinedTriObservable(observables, weakly=observe_weakly)
+
+
+def combine_values_observables(*observables: ValuesObservable[_S], observe_weakly: bool = False) -> ValuesObservable[_S]:
+    return CombinedValuesObservable(observables, weakly=observe_weakly)
 
 
 class _BaseObservable(Generic[_O], ABC):

--- a/tests/test_events/test_bi_events/test_derive_bi_event.py
+++ b/tests/test_events/test_bi_events/test_derive_bi_event.py
@@ -4,7 +4,7 @@ from spellbind.event import BiEvent
 
 def test_bi_event_merge():
     event = BiEvent[str, int]()
-    merged = event.map_to_one(lambda s, i: f"{s}-{i}")
+    merged = event.map_to_value_observable(lambda s, i: f"{s}-{i}")
     observer = OneParameterObserver()
     merged.observe(observer)
     event("foo", 1)
@@ -15,7 +15,7 @@ def test_bi_event_merge():
 
 def test_bi_event_merge_predicate():
     event = BiEvent[str, int]()
-    merged = event.map_to_one(lambda s, i: f"{s}-{i}", predicate=lambda s, i: i % 2 == 0)
+    merged = event.map_to_value_observable(lambda s, i: f"{s}-{i}", predicate=lambda s, i: i % 2 == 0)
     observer = OneParameterObserver()
     merged.observe(observer)
     event("foo", 1)
@@ -27,7 +27,7 @@ def test_bi_event_merge_predicate():
 
 def test_bi_event_map():
     event = BiEvent[str, int]()
-    mapped = event.map(lambda s, i: (s.upper(), i * 2))
+    mapped = event.map_to_bi_observable(lambda s, i: (s.upper(), i * 2))
     observer = TwoParametersObserver()
     mapped.observe(observer)
     event("foo", 1)
@@ -38,7 +38,7 @@ def test_bi_event_map():
 
 def test_bi_event_map_predicate():
     event = BiEvent[str, int]()
-    mapped = event.map(lambda s, i: (s.upper(), i * 2), predicate=lambda s, i: i % 2 == 0)
+    mapped = event.map_to_bi_observable(lambda s, i: (s.upper(), i * 2), predicate=lambda s, i: i % 2 == 0)
     observer = TwoParametersObserver()
     mapped.observe(observer)
     event("foo", 1)
@@ -50,7 +50,7 @@ def test_bi_event_map_predicate():
 
 def test_bi_event_split_to_three():
     event = BiEvent[str, int]()
-    split = event.map_to_three(lambda s, i: (s[0], s[1:], i))
+    split = event.map_to_tri_observable(lambda s, i: (s[0], s[1:], i))
     observer = ThreeParametersObserver()
     split.observe(observer)
     event("foo", 1)
@@ -61,7 +61,7 @@ def test_bi_event_split_to_three():
 
 def test_bi_event_split_to_three_predicate():
     event = BiEvent[str, int]()
-    split = event.map_to_three(
+    split = event.map_to_tri_observable(
         lambda s, i: (s[0], s[1:], i),
         predicate=lambda s, i: len(s) > 2
     )
@@ -84,7 +84,7 @@ def test_bi_event_called_only_after_observed():
         transform_calls.append((s, i))
         return f"{s}-{i}"
 
-    merged_event = event.map_to_one(transform)
+    merged_event = event.map_to_value_observable(transform)
     event("foo", 1)
     assert transform_calls == []
     assert event_observer.calls == [("foo", 1)]
@@ -101,7 +101,7 @@ def test_bi_event_called_only_after_observed():
 def test_unobserve_derived_bi_event():
     event = BiEvent[str, int]()
     observer = OneParameterObserver()
-    merged_event = event.map_to_one(lambda s, i: f"{s}-{i}")
+    merged_event = event.map_to_value_observable(lambda s, i: f"{s}-{i}")
     merged_event.observe(observer)
     assert event.is_observed()
 
@@ -124,8 +124,8 @@ def test_bi_event_chained_transformations():
         merge_calls.append((s, i))
         return f"{s}:{i}"
 
-    mapped = event.map(map_fn)
-    merged = mapped.map_to_one(merge_fn)
+    mapped = event.map_to_bi_observable(map_fn)
+    merged = mapped.map_to_value_observable(merge_fn)
 
     observer = OneParameterObserver()
     merged.observe(observer)

--- a/tests/test_events/test_bi_events/test_or_bi_events.py
+++ b/tests/test_events/test_bi_events/test_or_bi_events.py
@@ -1,11 +1,12 @@
 from conftest import NoParametersObserver, Call, TwoParametersObserver, void_observer
 from spellbind.event import Event, BiEvent
+from spellbind.observables import combine_bi_observables
 
 
 def test_adding_value_events_does_not_make_them_observed_until_derived_observed():
     event0 = BiEvent[str, str]()
     event1 = BiEvent[str, str]()
-    combined_event = event0.or_bi(event1)
+    combined_event = combine_bi_observables(event0, event1)
 
     assert not event0.is_observed()
     assert not event1.is_observed()
@@ -20,7 +21,7 @@ def test_adding_value_events_does_not_make_them_observed_until_derived_observed(
 def test_adding_value_events_observe_unobserve_makes_value_events_unobserved():
     event0 = BiEvent[str, str]()
     event1 = BiEvent[str, str]()
-    combined_event = event0.or_bi(event1)
+    combined_event = combine_bi_observables(event0, event1)
 
     combined_event.observe(void_observer)
     combined_event.unobserve(void_observer)
@@ -33,7 +34,7 @@ def test_adding_value_events_observe_unobserve_makes_value_events_unobserved():
 def test_calling_either_value_event_triggers_combined_value_event():
     event0 = BiEvent[str, str]()
     event1 = BiEvent[str, str]()
-    combined_event = event0.or_bi(event1)
+    combined_event = combine_bi_observables(event0, event1)
 
     observer = TwoParametersObserver()
     combined_event.observe(observer)
@@ -47,7 +48,7 @@ def test_calling_either_value_event_triggers_combined_value_event():
 def test_combine_value_event_with_event():
     event0 = BiEvent[str, str]()
     event1 = Event()
-    combined_event = event0 | event1
+    combined_event = event0.or_observable(event1)
 
     observer = NoParametersObserver()
     combined_event.observe(observer)

--- a/tests/test_events/test_events/test_or_events.py
+++ b/tests/test_events/test_events/test_or_events.py
@@ -6,7 +6,7 @@ from spellbind.observables import Observable
 def test_or_events_does_not_make_them_observed_until_derived_observed():
     event0 = Event()
     event1 = Event()
-    combined_event = event0 | event1
+    combined_event = event0.or_observable(event1)
 
     assert not event0.is_observed()
     assert not event1.is_observed()
@@ -21,7 +21,7 @@ def test_or_events_does_not_make_them_observed_until_derived_observed():
 def test_or_events_observe_unobserve_makes_events_unobserved():
     event0 = Event()
     event1 = Event()
-    combined_event: Observable = event0 | event1
+    combined_event: Observable = event0.or_observable(event1)
 
     combined_event.observe(void_observer)
     combined_event.unobserve(void_observer)
@@ -34,7 +34,7 @@ def test_or_events_observe_unobserve_makes_events_unobserved():
 def test_calling_either_event_triggers_combined_event():
     event0 = Event()
     event1 = Event()
-    combined_event = event0 | event1
+    combined_event = event0.or_observable(event1)
 
     observer = NoParametersObserver()
     combined_event.observe(observer)

--- a/tests/test_events/test_value_events/test_derive_value_events.py
+++ b/tests/test_events/test_value_events/test_derive_value_events.py
@@ -4,7 +4,7 @@ from spellbind.event import ValueEvent
 
 def test_derive_one():
     event = ValueEvent[str]()
-    derived = event.map(lambda s: len(s))
+    derived = event.map_to_value_observable(lambda s: len(s))
     observer = OneParameterObserver()
     derived.observe(observer)
     event("foo bar")
@@ -15,7 +15,7 @@ def test_derive_one():
 
 def test_derive_one_predicate():
     event = ValueEvent[str]()
-    derived = event.map(lambda s: len(s), predicate=lambda s: len(s) % 2 == 0)
+    derived = event.map_to_value_observable(lambda s: len(s), predicate=lambda s: len(s) % 2 == 0)
     observer = OneParameterObserver()
     derived.observe(observer)
     event("foo bar")
@@ -28,7 +28,7 @@ def test_derive_one_predicate():
 
 def test_derive_two():
     event = ValueEvent[str]()
-    derived = event.map_to_two(lambda s: (s[0:len(s) // 2], s[len(s) // 2:]))
+    derived = event.map_to_bi_observable(lambda s: (s[0:len(s) // 2], s[len(s) // 2:]))
     observer = TwoParametersObserver()
     derived.observe(observer)
     event("f")
@@ -40,7 +40,7 @@ def test_derive_two():
 
 def test_derive_two_predicate():
     event = ValueEvent[str]()
-    derived = event.map_to_two(lambda s: (s[0:len(s) // 2], s[len(s) // 2:]), predicate=lambda s: len(s) % 2 == 0)
+    derived = event.map_to_bi_observable(lambda s: (s[0:len(s) // 2], s[len(s) // 2:]), predicate=lambda s: len(s) % 2 == 0)
     observer = TwoParametersObserver()
     derived.observe(observer)
     event("f")
@@ -52,7 +52,7 @@ def test_derive_two_predicate():
 
 def test_derive_three():
     event = ValueEvent[str]()
-    derived = event.map_to_three(lambda s: (s[0:len(s) // 3], s[len(s) // 3:2 * len(s) // 3], s[2 * len(s) // 3:]))
+    derived = event.map_to_tri_observable(lambda s: (s[0:len(s) // 3], s[len(s) // 3:2 * len(s) // 3], s[2 * len(s) // 3:]))
     observer = ThreeParametersObserver()
     derived.observe(observer)
     event("foobar")
@@ -63,8 +63,8 @@ def test_derive_three():
 
 def test_derive_three_predicate():
     event = ValueEvent[str]()
-    derived = event.map_to_three(lambda s: (s[0:len(s) // 3], s[len(s) // 3:2 * len(s) // 3], s[2 * len(s) // 3:]),
-                                 predicate=lambda s: len(s) % 3 == 0)
+    derived = event.map_to_tri_observable(lambda s: (s[0:len(s) // 3], s[len(s) // 3:2 * len(s) // 3], s[2 * len(s) // 3:]),
+                                          predicate=lambda s: len(s) % 3 == 0)
     observer = ThreeParametersObserver()
     derived.observe(observer)
     event("foobar")
@@ -77,7 +77,7 @@ def test_derive_three_predicate():
 
 def test_derive_many():
     event = ValueEvent[str]()
-    derived = event.map_to_many(lambda s: s.split())
+    derived = event.map_to_values_observable(lambda s: s.split())
     observer = OneParameterObserver()
     derived.observe(observer)
     event("foobar")
@@ -94,7 +94,7 @@ def test_derive_many():
 
 def test_derive_many_predicate():
     event = ValueEvent[str]()
-    derived = event.map_to_many(lambda s: s.split(), predicate=lambda s: " " in s)
+    derived = event.map_to_values_observable(lambda s: s.split(), predicate=lambda s: " " in s)
     observer = OneParameterObserver()
     derived.observe(observer)
     event("x")
@@ -120,7 +120,7 @@ def test_value_event_called_only_after_derived_observed():
         plus_one_calls.append(value)
         return value + 1
 
-    derived_event = event.map(plus_one)
+    derived_event = event.map_to_value_observable(plus_one)
     event(3)
     assert plus_one_calls == []
     assert event_observer.calls == [3]
@@ -149,8 +149,8 @@ def test_value_event_called_only_after_derived_twice_observed():
         times_two_calls.append(value)
         return value * 2
 
-    derived_1 = event.map(plus_one)
-    derived_2 = derived_1.map(times_two)
+    derived_1 = event.map_to_value_observable(plus_one)
+    derived_2 = derived_1.map_to_value_observable(times_two)
     event(3)
     assert plus_one_calls == []
     assert times_two_calls == []
@@ -166,7 +166,7 @@ def test_value_event_called_only_after_derived_twice_observed():
 def test_unobserve_derived_event_silences_makes_event_unobserved():
     event = ValueEvent[int]()
     observer = OneParameterObserver()
-    derived_event = event.map(lambda x: x + 1)
+    derived_event = event.map_to_value_observable(lambda x: x + 1)
     derived_event.observe(observer)
     assert event.is_observed()
 

--- a/tests/test_events/test_value_events/test_or_value_events.py
+++ b/tests/test_events/test_value_events/test_or_value_events.py
@@ -5,7 +5,7 @@ from spellbind.event import ValueEvent, Event
 def test_adding_value_events_does_not_make_them_observed_until_derived_observed():
     event0 = ValueEvent[str]()
     event1 = ValueEvent[str]()
-    combined_event = event0.or_value(event1)
+    combined_event = event0.or_value_observable(event1)
 
     assert not event0.is_observed()
     assert not event1.is_observed()
@@ -20,7 +20,7 @@ def test_adding_value_events_does_not_make_them_observed_until_derived_observed(
 def test_adding_value_events_observe_unobserve_makes_value_events_unobserved():
     event0 = ValueEvent[str]()
     event1 = ValueEvent[str]()
-    combined_event = event0.or_value(event1)
+    combined_event = event0.or_value_observable(event1)
 
     combined_event.observe(void_observer)
     combined_event.unobserve(void_observer)
@@ -33,7 +33,7 @@ def test_adding_value_events_observe_unobserve_makes_value_events_unobserved():
 def test_calling_either_value_event_triggers_combined_value_event():
     event0 = ValueEvent[str]()
     event1 = ValueEvent[str]()
-    combined_event = event0.or_value(event1)
+    combined_event = event0.or_value_observable(event1)
 
     observer = OneParameterObserver()
     combined_event.observe(observer)
@@ -47,7 +47,7 @@ def test_calling_either_value_event_triggers_combined_value_event():
 def test_combine_value_event_with_event():
     event0 = ValueEvent[str]()
     event1 = Event()
-    combined_event = event0 | event1
+    combined_event = event0.or_observable(event1)
 
     observer = NoParametersObserver()
     combined_event.observe(observer)

--- a/tests/test_events/test_value_events/test_value_events.py
+++ b/tests/test_events/test_value_events/test_value_events.py
@@ -239,7 +239,7 @@ def test_value_event_lazy_evaluate_only_called_when_derived_observed():
     def lazy() -> int:
         lazy_calls.append("lazy")
         return 3
-    derived = event.map(lambda x: x + 1)
+    derived = event.map_to_value_observable(lambda x: x + 1)
     event.emit_lazy(lazy)
     assert lazy_calls == []
     derived.observe(void_observer)


### PR DESCRIPTION
Remove method __or__, since it conflicts with BoolValue.__or__. Replace with function combine_observables in module observables Rename some methods in Observable, so they functionality is less confusing when working with Values